### PR TITLE
Issue #14: Navigation to Assign Grades page.

### DIFF
--- a/src/pages/Assignments/ViewSubmissions.tsx
+++ b/src/pages/Assignments/ViewSubmissions.tsx
@@ -156,7 +156,7 @@ const ViewSubmissions: React.FC = () => {
   // reimplementation back end. In the current version of expertiza, the assign grades page links to
   // /grades/view_team?id=45297
   const handleAssignGradesClick = useCallback(
-    (row: TRow<ISubmission>) => navigate(`/assignments/edit/${row.original.id}`),
+    (row: TRow<ISubmission>) => navigate(`/grades/view_team/${row.original.id}`),
     [navigate]
   );
 


### PR DESCRIPTION
Fix handleAssignGradesClick on View Submissions page to navigate to the Assign Grade page. 

Closes #15 